### PR TITLE
Update new overtime element to use other element style

### DIFF
--- a/scripts/bob-monthly-overtime.js
+++ b/scripts/bob-monthly-overtime.js
@@ -90,11 +90,12 @@ function deletePreviousOvertime() {
 
 function appendOvertime() {
     deletePreviousOvertime();
-    const overtime = document.createElement('div');
     const summaryContainer = document.querySelector('b-summary-insights');
+    const overtime = summaryContainer.querySelector('b-label-value:last-child').cloneNode(true);
+
     overtime.id = 'overtime';
-    overtime.innerHTML = getOvertime().toString() + '<br>Overtime';
-    overtime.style.fontSize = '16px';
+    overtime.querySelector('h6 span').innerHTML = getOvertime().toString();
+    overtime.querySelector('p span').innerHTML = 'Overtime';
     summaryContainer.appendChild(overtime);
 }
 


### PR DESCRIPTION
Since [my brain is obsessed](https://en.wikipedia.org/wiki/Obsessive%E2%80%93compulsive_disorder) with the different styling of the new element, I updated the code to insert the new element to use the same style as the other elements.

Before:
<img width="1162" alt="Screenshot 2023-06-21 at 10 30 04" src="https://github.com/luca-landa/tampermonkey-scripts/assets/1719696/2c02c37f-a44c-4668-9669-5dea3741a5d1">

After:
<img width="1158" alt="Screenshot 2023-06-21 at 10 30 48" src="https://github.com/luca-landa/tampermonkey-scripts/assets/1719696/c5385664-22cb-49e9-ad54-889297bb82d5">
