### PR TITLE
Floor minutes; also fix tiny bug with hours formatting

### DIFF
--- a/scripts/bob-monthly-overtime.js
+++ b/scripts/bob-monthly-overtime.js
@@ -39,10 +39,11 @@ class Time {
 
     toString() {
         const hours = Math.abs(this.hours)
-        let minutes = Math.abs(this.minutes);
-        const hoursString = minutes < 10 ? `0${hours}` : hours.toString();
-        const minutesString = minutes < 10 ? `0${minutes}` : minutes.toString();
+        const minutes = Math.abs(this.minutes);
+        const hoursString = hours.toString().padStart(2, '0');
+        const minutesString = Math.floor(minutes).toString().padStart(2, '0');
         const sign = this.positive ? '+' : '-';
+
         return `${sign}${hoursString}:${minutesString}`;
     }
 }


### PR DESCRIPTION
Hey! 🙌 
I'm proposing a tiny change to how the time is represented as a string based on some edge case I experienced today.

Also, a tiny fix for the hours representation.

A couple of screenshots to illustrate:

**Before**
![Screenshot 2023-07-13 at 10 08 51](https://github.com/luca-landa/tampermonkey-scripts/assets/1634023/f605e377-2e4f-4ba9-93bb-3e34b79539fb)

**After**
![Screenshot 2023-07-13 at 10 22 22](https://github.com/luca-landa/tampermonkey-scripts/assets/1634023/f7cae331-4b10-42eb-86d9-86f01d91f42b)
